### PR TITLE
Turn off test data upload

### DIFF
--- a/data_upload/urls.py
+++ b/data_upload/urls.py
@@ -8,5 +8,5 @@ admin.autodiscover()
 urlpatterns = patterns('',
 
     url(r'^upload$', views.upload_file, name='project_data_upload'),
-    url(r'^test$', views.test_form, name='data_upload_test'),
+    #url(r'^test$', views.test_form, name='data_upload_test'),
 )


### PR DESCRIPTION
We don't need this on and since we don't do any validation and it goes into our bucket, we shouldn't leave it on.
